### PR TITLE
B-07: Remove redundant back button from header

### DIFF
--- a/src/pages/BookingPage.tsx
+++ b/src/pages/BookingPage.tsx
@@ -266,13 +266,8 @@ const BookingPage: React.FC = () => {
   return (
     <div className="relative flex h-auto min-h-screen w-full max-w-md mx-auto flex-col bg-stone-50 overflow-x-hidden">
       {/* Top Navigation */}
-      <header className="flex items-center p-4 justify-between sticky top-0 bg-stone-50/80 backdrop-blur-md z-10 border-b border-stone-200">
-        <div className="flex size-10 items-center justify-center rounded-full hover:bg-stone-200 transition-colors cursor-pointer text-primary">
-          <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-          </svg>
-        </div>
-        <h1 className="text-xl font-semibold leading-tight tracking-tight flex-1 text-center pr-10 text-primary font-display">Book Your Flow</h1>
+      <header className="flex items-center p-4 justify-center sticky top-0 bg-stone-50/80 backdrop-blur-md z-10 border-b border-stone-200">
+        <h1 className="text-xl font-semibold leading-tight tracking-tight text-primary font-display">Book Your Flow</h1>
       </header>
 
       <main className="flex-1 pb-32 px-4">


### PR DESCRIPTION
Removes redundant back button from Book a Class page header as it duplicates logo navigation functionality.

Closes #18

## Problem Fixed
- Header had redundant back button that duplicates logo navigation
- Creates confusion with multiple navigation options  
- Violates standard web conventions where logo handles home navigation

## Solution Implemented
- Removed redundant back button (left arrow SVG icon)
- Simplified header layout to center the title cleanly
- Updated header styles for optimal centered layout
- Maintained all other header functionality and aesthetics

## User Experience Impact
- Cleaner, less cluttered header design
- Follows standard web conventions (logo = home navigation)
- Eliminates navigation confusion  
- Maintains professional, minimal aesthetic
- No functional regression - logo still handles navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)